### PR TITLE
fix(shell): configure remote tracking in gbclone

### DIFF
--- a/nix/dotfiles/common/.config/fish/custom/functions/gbclone.fish
+++ b/nix/dotfiles/common/.config/fish/custom/functions/gbclone.fish
@@ -16,7 +16,10 @@ function gbclone -d "clone a repo into a bare .git dir with a default-branch wor
   end
 
   command git clone --bare "$repo_url" "$repo_name/.git"; or return
+  command git --git-dir="$repo_name/.git" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'; or return
+  command git --git-dir="$repo_name/.git" fetch origin; or return
 
   set -l default_branch (path basename (command git --git-dir="$repo_name/.git" symbolic-ref HEAD)); or return
+  command git --git-dir="$repo_name/.git" branch --set-upstream-to="origin/$default_branch" "$default_branch"; or return
   command git --git-dir="$repo_name/.git" worktree add "$repo_name/$default_branch" "$default_branch"
 end


### PR DESCRIPTION
## Summary
- configure the standard origin fetch refspec after a bare clone
- fetch remote-tracking refs
- set the default branch upstream before creating its worktree

## Validation
- `fish -n nix/dotfiles/common/.config/fish/custom/functions/gbclone.fish`
- end-to-end temporary bare-clone/worktree test