### PR TITLE
fix(root): streamline validation and Pi session naming

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ jobs:
       - run: nix run .#statix -- check .
       - run: nix run .#deadnix -- --fail .
       - run: nix flake check --all-systems --no-build
-      - run: nix build --no-link .#checks.x86_64-linux.{immutable-plugin-policy,audit-external-state}
+      - run: nix build --no-link .#checks.x86_64-linux.{personal-arch,personal-debian,immutable-plugin-policy,audit-external-state}
       - run: git diff --check
 
 

--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ Run comprehensive validation explicitly with:
 ./bin/nix-validate
 ```
 
-GitHub Actions runs formatting, static analysis, all-system evaluation, and lightweight Linux checks on Ubuntu. A separate hosted Apple Silicon job fully realizes both Darwin configurations plus the Comin deployment and launchd-boundary checks. Protected `main` requires both the `lint` and `darwin` jobs before GitHub creates its signed squash commit.
+GitHub Actions runs formatting, static analysis, all-system evaluation, and fully realizes both Linux Home Manager configurations plus the Linux checks on Ubuntu. A separate hosted Apple Silicon job fully realizes both Darwin configurations plus the Comin deployment and launchd-boundary checks. Protected `main` requires both the `lint` and `darwin` jobs before GitHub creates its signed squash commit.
 
-`./bin/nix-validate` fully builds every configuration for the current platform: both Darwin configurations on macOS or both Home Manager configurations on Linux. It also builds the custom packages and checks for that platform. Lefthook runs this comprehensive command before pushes containing relevant Nix-managed changes; a validation failure blocks the push unless an emergency push intentionally uses `git push --no-verify`.
+`./bin/nix-validate` provides the same comprehensive validation as an explicit local preflight for the current platform. Lefthook only enforces commit-message formatting; protected `main` and the required GitHub Actions jobs enforce repository validation before merge.
 
-Cross-platform realization remains platform-specific locally: Darwin cannot natively build the Linux configurations, and Linux cannot natively build the Darwin configurations. Cross-platform configurations still receive evaluation-only coverage.
+Cross-platform realization remains platform-specific locally: Darwin cannot natively build the Linux configurations, and Linux cannot natively build the Darwin configurations. GitHub Actions realizes every supported configuration on its native platform.
 
 The pinned nixpkgs revision needs one narrow Darwin build workaround: oxlint's `@napi-rs/cli` process probe is redirected from sandbox-blocked `/bin/ps` to Nix's store-backed `ps`. Revisit this override when updating `nixpkgs`.
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,14 +2,3 @@ commit-msg:
   commands:
     commitlint:
       run: bunx commitlint --edit {1}
-
-pre-push:
-  commands:
-    nix-validate:
-      glob:
-        - "flake.nix"
-        - "flake.lock"
-        - "nix/**"
-        - "pi-extensions/**"
-        - "bin/nix-*"
-      run: ./bin/nix-validate

--- a/nix/dotfiles/common/.config/tmux/scripts/pi-session-lib.mjs
+++ b/nix/dotfiles/common/.config/tmux/scripts/pi-session-lib.mjs
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { basename, isAbsolute, join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { homedir } from "node:os";
 
 export const FIELD_SEPARATOR = "\u001f";
@@ -249,8 +249,8 @@ export const formatElapsed = (timestamp, now) => {
 	return `${Math.floor(hours / 24)}d`;
 };
 
-const projectName = (cwd, pane) =>
-	sanitizeDisplayText(cwd ? basename(cwd) : pane.sessionName, 80) || "-";
+const tmuxSessionName = (pane) =>
+	sanitizeDisplayText(pane.sessionName, 80) || "tmux session";
 
 const displayBranch = (branch) => (branch ? `${BRANCH_ICON} ${branch}` : "-");
 
@@ -265,12 +265,12 @@ const displayState = (row) =>
 
 const renderRow = (row) => {
 	const style = STATUS_STYLE[row.status];
-	const project = row.project.padEnd(row.projectColumnWidth);
+	const sessionName = row.sessionName.padEnd(row.sessionNameColumnWidth);
 	const branch = displayBranch(row.branch).padEnd(row.branchColumnWidth);
 	const state = displayState(row).padEnd(row.stateColumnWidth);
 	const ageGap = " ".repeat(row.sessionAgeGapWidth);
 	const sessionAge = row.sessionAge.padStart(row.sessionAgeColumnWidth);
-	return `${TEXT}${project}${RESET} ${BRANCH}${branch}${RESET} ${style.color}${style.glyph} ${state}${RESET}${ageGap}${MUTED}${sessionAge}${RESET}`;
+	return `${TEXT}${sessionName}${RESET} ${BRANCH}${branch}${RESET} ${style.color}${style.glyph} ${state}${RESET}${ageGap}${MUTED}${sessionAge}${RESET}`;
 };
 
 export const buildRows = ({
@@ -297,7 +297,7 @@ export const buildRows = ({
 		const status = fresh && isKnownStatus(heartbeat.state)
 			? heartbeat.state
 			: "UNKNOWN";
-		const title = pane.sessionName || "tmux session";
+		const sessionName = tmuxSessionName(pane);
 		const stateTimestamp = heartbeat
 			? Math.min(now, heartbeat.stateChangedAt)
 			: Math.min(now, pane.windowActivity * 1_000 || now);
@@ -313,9 +313,9 @@ export const buildRows = ({
 			windowId: pane.windowId,
 			status,
 			toolName: fresh ? heartbeat.toolName : undefined,
-			title,
+			title: sessionName,
 			tmuxTarget: `${pane.windowIndex}.${pane.paneIndex}`,
-			project: projectName(cwd, pane),
+			sessionName,
 			branch,
 			stateTimestamp,
 			elapsed: formatElapsed(stateTimestamp, now),
@@ -337,8 +337,8 @@ export const buildRows = ({
 		return Number(left.paneId.slice(1)) - Number(right.paneId.slice(1));
 	});
 
-	const projectColumnWidth = rows.reduce(
-		(width, row) => Math.max(width, row.project.length),
+	const sessionNameColumnWidth = rows.reduce(
+		(width, row) => Math.max(width, row.sessionName.length),
 		0,
 	);
 	const branchColumnWidth = rows.reduce(
@@ -354,7 +354,7 @@ export const buildRows = ({
 		0,
 	);
 	const minimumRowWidth =
-		projectColumnWidth +
+		sessionNameColumnWidth +
 		1 +
 		branchColumnWidth +
 		1 +
@@ -367,7 +367,7 @@ export const buildRows = ({
 			? Math.max(1, displayWidth - minimumRowWidth + 1)
 			: 1;
 	for (const row of rows) {
-		row.projectColumnWidth = projectColumnWidth;
+		row.sessionNameColumnWidth = sessionNameColumnWidth;
 		row.branchColumnWidth = branchColumnWidth;
 		row.stateColumnWidth = stateColumnWidth;
 		row.sessionAgeColumnWidth = sessionAgeColumnWidth;

--- a/nix/dotfiles/common/.config/tmux/scripts/pi-session-lib.test.mjs
+++ b/nix/dotfiles/common/.config/tmux/scripts/pi-session-lib.test.mjs
@@ -281,10 +281,16 @@ test("keeps the opening pane order while appending newly discovered panes", () =
 	assert.deepEqual(orderedRows.map((row) => row.paneId), ["%2", "%1", "%3"]);
 });
 
-test("keeps stable hidden targets separate from sanitized display text", () => {
+test("shows the sanitized tmux session name instead of the project name", () => {
 	const project = "project-name-that-exceeds-twenty-four-characters";
+	const tmuxSession = "work session";
 	const rows = buildRows({
-		panes: [pane({ paneTitle: "π - malicious\t$(touch /tmp/nope)\nname" })],
+		panes: [
+			pane({
+				sessionName: "work\tsession",
+				paneTitle: "π - malicious\t$(touch /tmp/nope)\nname",
+			}),
+		],
 		heartbeats: [
 			heartbeat({
 				sessionName: "bad\tname\u001b[31m",
@@ -297,24 +303,24 @@ test("keeps stable hidden targets separate from sanitized display text", () => {
 			cwd === `/tmp/${project}` ? "feature/pi-picker" : "",
 	});
 	const candidate = rowToCandidate(rows[0]);
-	assert.equal(rows[0].title, "dotfiles");
+	assert.equal(rows[0].title, tmuxSession);
 	assert.equal(rows[0].tmuxTarget, "1.1");
-	assert.equal(rows[0].project, project);
+	assert.equal(rows[0].sessionName, tmuxSession);
 	assert.equal(rows[0].branch, "feature/pi-picker");
 	assert.equal(rows[0].sessionAge, "15m");
 	assert.equal(candidate.includes("bad name"), false);
 	const [paneId, sessionId, windowId, display] = candidate.split("\t");
 	assert.deepEqual([paneId, sessionId, windowId], ["%1", "$1", "@1"]);
 	assert.equal(display.includes("\u001b]52"), false);
-	assert.equal(display.includes("dotfiles"), false);
+	assert.equal(display.includes(project), false);
 	assert.equal(display.includes("1.1"), false);
-	const projectIndex = display.indexOf(project);
+	const sessionIndex = display.indexOf(tmuxSession);
 	const branchIndex = display.indexOf("\uF126 feature/pi-picker");
 	const statusIndex = display.indexOf("WAITING");
 	const elapsedIndex = display.indexOf("2m");
 	const sessionAgeIndex = display.indexOf("15m");
 	assert.equal(
-		projectIndex < branchIndex &&
+		sessionIndex < branchIndex &&
 			branchIndex < statusIndex &&
 			statusIndex < elapsedIndex &&
 			elapsedIndex < sessionAgeIndex,


### PR DESCRIPTION
## Summary
- show the tmux session name in the Alt+P Pi picker instead of the project directory name
- rename the row and column fields to match the displayed value and cover sanitized tmux session names
- remove comprehensive pre-push validation in favor of protected-branch GitHub Actions
- fully realize both Linux Home Manager configurations in the required `lint` job while retaining explicit local validation and commit-message enforcement

## Tests
- `node --test nix/dotfiles/common/.config/tmux/scripts/pi-session-lib.test.mjs`
- `./bin/nix-validate`
