### PR TITLE
ci(nix): validate Pi extensions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,10 +18,21 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
         with:
           extra_nix_config: experimental-features = nix-command flakes
       - run: ./bin/check-dependency-sync
+      - name: Validate Pi extensions
+        working-directory: pi-extensions
+        env:
+          COREPACK_ENABLE_PROJECT_SPEC: "1"
+        run: |
+          corepack npm ci
+          corepack npm run ci
       - run: nix fmt -- --ci --tree-root . --walk filesystem
       - run: nix run .#statix -- check .
       - run: nix run .#deadnix -- --fail .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.13
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31
         with:
           extra_nix_config: experimental-features = nix-command flakes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,4 @@ Fish configuration/plugins are store-backed. Linux Fish remains a native login-s
 
 ## Commit standards
 
-Commits use `type(scope): message` with scopes `root`, `agents`, `nvim`, `mac`, `shell`, or `tmux`. Never add `Co-authored-by` trailers.
+Commits use `type(scope): message` with scopes `root`, `nix`, `agents`, `nvim`, `mac`, `shell`, or `tmux`. Never add `Co-authored-by` trailers.

--- a/bin/nix-validate
+++ b/bin/nix-validate
@@ -3,6 +3,12 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 ./bin/check-dependency-sync
+(
+  cd pi-extensions
+  export COREPACK_ENABLE_PROJECT_SPEC=1
+  corepack npm ci
+  corepack npm run ci
+)
 nix fmt -- --ci --tree-root . --walk filesystem
 nix run .#statix -- check .
 nix run .#deadnix -- --fail .

--- a/nix/modules/common/runtimes.nix
+++ b/nix/modules/common/runtimes.nix
@@ -11,8 +11,5 @@
     pkgs.rustfmt
   ];
 
-  home.sessionVariables = {
-    COREPACK_ENABLE_PROJECT_SPEC = "0";
-    RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
-  };
+  home.sessionVariables.RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
 }

--- a/nix/packages/pi-extensions/update.sh
+++ b/nix/packages/pi-extensions/update.sh
@@ -7,6 +7,13 @@ check_script="$repo_root/bin/check-dependency-sync"
 target="${1:-all}"
 requested_version="${2:-}"
 
+project_npm() {
+  (
+    cd "$repo_root/pi-extensions"
+    COREPACK_ENABLE_PROJECT_SPEC=1 corepack npm "$@"
+  )
+}
+
 set_dependency_version() {
   local package_name="$1"
   local version="$2"
@@ -20,7 +27,7 @@ update_dependency() {
   local package_name="$1"
   local version="${2:-}"
   if [ -z "$version" ]; then
-    version="$(npm view "$package_name" version)"
+    version="$(project_npm view "$package_name" version)"
   fi
   set_dependency_version "$package_name" "$version"
 }
@@ -43,8 +50,7 @@ case "$target" in
     ;;
 esac
 
-cd "$repo_root/pi-extensions"
-npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+project_npm install --package-lock-only --ignore-scripts --no-audit --no-fund
 cd "$repo_root"
 "$check_script"
 nix build "$repo_root#pi-extensions.dependencies" --no-link


### PR DESCRIPTION
## Summary
- run the Pi extension lint, typecheck, and coverage suite in local Nix validation and CI
- use the project-pinned npm through Corepack for Pi extension updates without exporting a global Corepack override
- document the supported `nix` commit scope

## Testing
- `./bin/nix-validate`