### PR TITLE
chore(root): enable Renovate platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
       ],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": false,
+      "platformAutomerge": true,
       "ignoreTests": false
     },
     {


### PR DESCRIPTION
Uses GitHub native automerge for Renovate PRs so they merge promptly once CI passes.

The default branch now requires the GitHub Actions `ubuntu` and `macos` checks, both pinned to the GitHub Actions integration, before updates can merge.